### PR TITLE
feat(step-ca): Step CA LXC now works

### DIFF
--- a/modules/stepca-lxc/main.tf
+++ b/modules/stepca-lxc/main.tf
@@ -102,7 +102,7 @@ resource "ssh_resource" "configure_host" {
     EOT
   ]
 
-  timeout = "2m"
+  timeout = "75s"
 }
 
 # ACME Cleanup on destroy

--- a/modules/stepca-lxc/providers.tf
+++ b/modules/stepca-lxc/providers.tf
@@ -4,11 +4,15 @@ terraform {
   required_providers {
     proxmox = {
       source  = "bpg/proxmox"
-      version = ">= 0.78.1"
+      version = ">= 0.85.1"
     }
     ssh = {
       source  = "loafoe/ssh"
-      version = "~> 2.7"
+      version = ">= 2.7.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.7.2"
     }
   }
 }

--- a/modules/stepca-lxc/variables.tf
+++ b/modules/stepca-lxc/variables.tf
@@ -58,7 +58,7 @@ variable "mount_points" {
 variable "imagestore_id" {
   description = "Step-CA imagestore ID"
   type        = string
-  default     = "proxmox-resources"
+  default     = "virt-assets"
   nullable    = false
 }
 
@@ -130,7 +130,7 @@ variable "acme_name" {
 variable "acme_proxmox_domains" {
   description = "Proxmox ACME domains to order certificates for"
   type        = list(string)
-  default     = ["sanctum.my.world", "sanctum.fritz.box"]
+  default     = ["sanctum.my.world"]
   nullable    = false
 }
 


### PR DESCRIPTION
Step CA LXC Terraform script now works; however: it requires you to manually add the proper Debian APT repository.